### PR TITLE
README.md: corrections to correctly display regex and ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ Humre also provides constants for commonly used patterns:
 | `NONLOWERCASE` | (too big to display) | Matches `not islower()` |
 | `ALPHANUMERIC` | (too big to display) | Matches `isalnum()` |
 | `NONALPHANUMERIC` | (too big to display) | Matches `not isalnum()` |
-| `HEXADECIMAL` | `'[0-9A-f]'` | |
-| `NONHEXADECIMAL` | `'[^0-9A-f]'` | |
-| `NUMBER` | `r'(?:\+|-)?(?:(?:\d{1,3}(?:,\d{3})+)|\d+)(?:\.\d+)?'` | Comma-formatted numbers |
-| `EURO_NUMBER` | `r'(?:\+|-)?(?:(?:\d{1,3}(?:\.\d{3})+)|\d+)(?:,\d+)?'` | Period-formatted numbers |
-| `HEXADECIMAL_NUMBER` | `'(?:(?:0x|0X)[0-9a-f]+)|(?:(?:0x|0X)[0-9A-F]+)|(?:[0-9a-f]+)|(?:[0-9A-F]+)'` | Can have leading `0x` or `0X`. |
+| `HEXADECIMAL` | `'[0-9A-Fa-f]'` | |
+| `NONHEXADECIMAL` | `'[^0-9A-Fa-f]'` | |
+| `NUMBER` | `r'(?:\+\|-)?(?:(?:\d{1,3}(?:,\d{3})+)\|\d+)(?:\.\d+)?'` | Comma-formatted numbers |
+| `EURO_NUMBER` | `r'(?:\+\|-)?(?:(?:\d{1,3}(?:\.\d{3})+)\|\d+)(?:,\d+)?'` | Period-formatted numbers |
+| `HEXADECIMAL_NUMBER` | `'(?:(?:0x\|0X)[0-9a-f]+)\|(?:(?:0x\|0X)[0-9A-F]+)\|(?:[0-9a-f]+)\|(?:[0-9A-F]+)'` | Can have leading `0x` or `0X`. |
 | `ASCII_LETTER` | `'[A-Za-z]'` | |
 | `ASCII_NONLETTER` | `'[^A-Za-z]'` | |
 | `ASCII_UPPERCASE` | `'[A-Z]'` | |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Humre provides constants for the `\d`, `\w`, and `\s` character classes as well 
 | `OPEN_BRACKET` | `r'\['` |
 | `CLOSE_BRACKET` | `r'\]'` |
 | `BACKSLASH` | `r'\\'` |
-| `PIPE` | `r'\|'` |
+| `PIPE` | `r'\\|'` |
 | `BACK_1` | `r'\1'` |
 | `BACK_2` | `r'\2'` |
 | `BACK_3` | `r'\3'` |


### PR DESCRIPTION
character sets for HEXADECIMAL and NONHEXIDECIMAL were shown
wit defined range of A-f, but has to be A-Fa-f.

Corrected the displaying of regex in markdown where '|' is used,
by escaping them with backslash.