### PR TITLE
fix: pipe(|) character rendering in readme tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Here's a quick list of all of Humre's functions and constants, and the regex str
 |----------------|------------------|
 | `group('A')` | `'(A)'` |
 | `optional('A')` | `'A?'` |
-| `either('A', 'B', 'C')` | `'A|B|C'` |
+| `either('A', 'B', 'C')` | `'A\|B\|C'` |
 | `exactly(3, 'A')` | `'A{3}'` |
 | `between(3, 5, 'A')` | `'A{3:5}'` |
 | `at_least(3, 'A')` | `'A{3,}'` |
@@ -183,8 +183,8 @@ The convenience group functions combine a Humre function with the `group()` (or 
 |----------------------------|---------------------|------------------|
 | `optional_group('A')` | `optional(noncap_group('A'))` | `'(A)?'` |
 | `optional_noncap_group('A')` | `optional(noncap_group('A'))` | `'(?:A)?'` |
-| `group_either('A')` | `noncap_group(either('A', 'B', 'C'))` | `'(A|B|C)'` |
-| `noncap_group_either('A')` | `noncap_group(either('A', 'B', 'C'))` | `'(?:A|B|C)'` |
+| `group_either('A')` | `noncap_group(either('A', 'B', 'C'))` | `'(A\|B\|C)'` |
+| `noncap_group_either('A')` | `noncap_group(either('A', 'B', 'C'))` | `'(?:A\|B\|C)'` |
 | `group_exactly('A')` | `noncap_group(exactly(3, 'A'))` | `'(A){3}'` |
 | `noncap_group_exactly('A')` | `noncap_group(exactly(3, 'A'))` | `'(?:A){3}'` |
 | `group_between('A')` | `noncap_group(between(3, 5, 'A'))` | `'(A){3,5}'` |


### PR DESCRIPTION
Replaced `|` with `\|` within the tables wherever required to make sure the content is rightly displayed. Markdown syntax for the column was overriding the same, hence added the escape character `\` to fix it.